### PR TITLE
Fix prompt copy functionality to preserve markdown formatting

### DIFF
--- a/.app/lib/modules/prompt-copy/prompt-copy.data.js
+++ b/.app/lib/modules/prompt-copy/prompt-copy.data.js
@@ -46,17 +46,18 @@ export default function promptCopyData(Alpine) {
         let currentElement = button.nextElementSibling; // Start after the button
         
         while (currentElement && currentElement.tagName !== 'HR') {
-          contentElements.push(currentElement);
+          // Skip button elements and copy-related elements
+          if (!this.shouldSkipElement(currentElement)) {
+            contentElements.push(currentElement);
+          }
           currentElement = currentElement.nextElementSibling;
         }
         
-        // Extract text from all collected elements
-        const textContent = contentElements
-          .map(el => el.innerText || el.textContent)
-          .join('\n\n');
+        // Convert to markdown preserving formatting
+        const markdownContent = this.convertToMarkdown(contentElements);
         
         // Copy to clipboard using modern Clipboard API
-        await navigator.clipboard.writeText(textContent);
+        await navigator.clipboard.writeText(markdownContent);
         
         // Update button state
         this.showCopiedState(button);
@@ -74,18 +75,19 @@ export default function promptCopyData(Alpine) {
         let currentElement = button.nextElementSibling; // Start after the button
         
         while (currentElement && currentElement.tagName !== 'HR') {
-          contentElements.push(currentElement);
+          // Skip button elements and copy-related elements
+          if (!this.shouldSkipElement(currentElement)) {
+            contentElements.push(currentElement);
+          }
           currentElement = currentElement.nextElementSibling;
         }
         
-        // Extract text from all collected elements
-        const textContent = contentElements
-          .map(el => el.innerText || el.textContent)
-          .join('\n\n');
+        // Convert to markdown preserving formatting
+        const markdownContent = this.convertToMarkdown(contentElements);
         
         // Create a temporary textarea
         const textarea = document.createElement('textarea');
-        textarea.value = textContent;
+        textarea.value = markdownContent;
         document.body.appendChild(textarea);
         
         // Select and copy
@@ -103,6 +105,162 @@ export default function promptCopyData(Alpine) {
         // Show error state
         this.showErrorState(button);
       }
+    },
+    
+    shouldSkipElement(element) {
+      // Skip button elements
+      if (element.tagName === 'BUTTON') {
+        return true;
+      }
+      
+      // Skip elements with copy-related classes
+      if (element.classList && (
+        element.classList.contains('code-block__copy') ||
+        element.classList.contains('prompt-copy-btn') ||
+        element.classList.contains('copy-btn')
+      )) {
+        return true;
+      }
+      
+      // Skip if the element contains only button children
+      if (element.children.length === 1 && element.children[0].tagName === 'BUTTON') {
+        return true;
+      }
+      
+      return false;
+    },
+    
+    convertToMarkdown(elements) {
+      const markdown = elements.map(element => this.elementToMarkdown(element)).join('\n\n');
+      
+      // Normalize whitespace: replace multiple consecutive newlines with double newlines
+      return markdown
+        .replace(/\n{3,}/g, '\n\n')  // Replace 3+ newlines with 2
+        .replace(/^\s+|\s+$/g, '')   // Trim leading/trailing whitespace
+        .replace(/[ \t]+$/gm, '');   // Remove trailing spaces/tabs from lines
+    },
+    
+    elementToMarkdown(element) {
+      const tagName = element.tagName.toLowerCase();
+      
+      switch (tagName) {
+        case 'h1':
+          return `# ${element.textContent}`;
+        case 'h2':
+          return `## ${element.textContent}`;
+        case 'h3':
+          return `### ${element.textContent}`;
+        case 'h4':
+          return `#### ${element.textContent}`;
+        case 'h5':
+          return `##### ${element.textContent}`;
+        case 'h6':
+          return `###### ${element.textContent}`;
+        
+        case 'p':
+          return this.processInlineElements(element);
+        
+        case 'ul':
+          return this.processListItems(element, '- ');
+        
+        case 'ol':
+          return this.processOrderedListItems(element);
+        
+        case 'pre':
+          const codeElement = element.querySelector('code');
+          if (codeElement) {
+            const language = this.extractLanguageFromClass(codeElement.className);
+            return '```' + language + '\n' + codeElement.textContent + '\n```';
+          }
+          return '```\n' + element.textContent + '\n```';
+        
+        case 'blockquote':
+          return element.textContent.split('\n').map(line => `> ${line}`).join('\n');
+        
+        case 'div':
+          // Handle div elements by processing their children, but skip if it's a code-block wrapper
+          if (element.classList && element.classList.contains('code-block')) {
+            // For code-block divs, extract just the pre/code content
+            const preElement = element.querySelector('pre');
+            if (preElement) {
+              return this.elementToMarkdown(preElement);
+            }
+          }
+          return this.processInlineElements(element);
+        
+        case 'button':
+          // Skip button elements entirely
+          return '';
+        
+        default:
+          return this.processInlineElements(element);
+      }
+    },
+    
+    processInlineElements(element) {
+      let result = '';
+      
+      for (const node of element.childNodes) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          result += node.textContent;
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          const tagName = node.tagName.toLowerCase();
+          
+          switch (tagName) {
+            case 'strong':
+            case 'b':
+              result += `**${node.textContent}**`;
+              break;
+            case 'em':
+            case 'i':
+              result += `*${node.textContent}*`;
+              break;
+            case 'code':
+              result += `\`${node.textContent}\``;
+              break;
+            case 'a':
+              const href = node.getAttribute('href') || '';
+              result += `[${node.textContent}](${href})`;
+              break;
+            case 'br':
+              result += '\n';
+              break;
+            case 'button':
+              // Skip button elements and their content
+              break;
+            case 'svg':
+              // Skip SVG elements (often used in buttons)
+              break;
+            default:
+              // Skip elements with copy-related classes
+              if (node.classList && (
+                node.classList.contains('code-block__copy') ||
+                node.classList.contains('prompt-copy-btn') ||
+                node.classList.contains('copy-btn')
+              )) {
+                break;
+              }
+              result += node.textContent;
+          }
+        }
+      }
+      
+      return result;
+    },
+    
+    processListItems(listElement, prefix) {
+      const items = Array.from(listElement.querySelectorAll('li'));
+      return items.map(item => prefix + this.processInlineElements(item)).join('\n');
+    },
+    
+    processOrderedListItems(listElement) {
+      const items = Array.from(listElement.querySelectorAll('li'));
+      return items.map((item, index) => `${index + 1}. ${this.processInlineElements(item)}`).join('\n');
+    },
+    
+    extractLanguageFromClass(className) {
+      const match = className.match(/language-(\w+)/);
+      return match ? match[1] : '';
     },
     
     showCopiedState(button) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Conventional Commits](https://conventionalcommits.org/).
 
+## [2025-06-29] - Prompt Copy Markdown Fix
+
+### Fixed
+- Fixed prompt copy functionality to preserve markdown formatting instead of copying plain text
+- Updated copyPromptContent and fallbackCopyToClipboard methods to use markdown conversion
+- Added comprehensive markdown conversion supporting headers, code blocks, lists, bold/italic text, and links
+- Filtered out copy-to-clipboard button elements and SVG icons from copied markdown content
+- Added whitespace normalization to prevent excessive newlines and formatting artifacts
+
 ## [2025-06-29] - Obsidian Integration
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Conventional Commits](https://conventionalcommits.o
 - Filtered out copy-to-clipboard button elements and SVG icons from copied markdown content
 - Added whitespace normalization to prevent excessive newlines and formatting artifacts
 
+### Changed
+- Improved Jira ticket prompt with concrete examples and better formatting
+
+### Added
+- Conventional Commits guidelines to CLAUDE.md for consistent commit message formatting
+
 ## [2025-06-29] - Obsidian Integration
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,71 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Conventional Commits](https://conventionalcommits.org/).
 
-## [2025-06-29] - Prompt Copy Markdown Fix
-
-### Fixed
-- Fixed prompt copy functionality to preserve markdown formatting instead of copying plain text
-- Updated copyPromptContent and fallbackCopyToClipboard methods to use markdown conversion
-- Added comprehensive markdown conversion supporting headers, code blocks, lists, bold/italic text, and links
-- Filtered out copy-to-clipboard button elements and SVG icons from copied markdown content
-- Added whitespace normalization to prevent excessive newlines and formatting artifacts
-
-### Changed
-- Improved Jira ticket prompt with concrete examples and better formatting
+## [2025-06-29] - Comprehensive Site Enhancement
 
 ### Added
-- Conventional Commits guidelines to CLAUDE.md for consistent commit message formatting
-
-## [2025-06-29] - Obsidian Integration
-
-### Added
+- Eleventy-based AI prompts documentation site with Obsidian-style note-taking integration
+- Static site generation with wikilinks support and task prompt template
+- New guides/resources.md file containing official Claude Code documentation links
+- Official Claude Code documentation section to index.md with links to Anthropic's official resources
+- Detailed summaries for Claude Code documentation and Anthropic Quickstarts CLAUDE.md
 - Obsidian configuration documentation in .obsidian/README.md
-- File ignore plugin configuration for clean Obsidian workspace
-- Comprehensive file exclusion patterns for build artifacts
+- File ignore plugin configuration for clean Obsidian workspace with comprehensive file exclusion patterns
+- CHANGELOG.md file following Keep a Changelog format
+- Conventional commits guidelines to CLAUDE.md documentation
+- Cross-platform line ending configuration for consistent development
+- Site favicon from rlew.io and HTML page title suffixes for better SEO
+- Renovate bot configuration for automated dependency management with enhanced project-specific settings
+- Community Resources section with Awesome Claude Code repository link
+- UK English spelling conventions applied to new documentation
+- Claude Code website link to README.md Resources section
+- Comprehensive markdown conversion supporting headers, code blocks, lists, bold/italic text, and links
 
 ### Changed
+- Moved Resources section from index.md to dedicated guides/resources.md file
+- Removed reference to .plans/00-SETUP.md from troubleshooting section
+- Added invitation to create GitHub issues for troubleshooting help
+- Reduced spacing between copy prompt button and following headers for better visual flow
+- Applied consistent spacing for paragraphs following copy prompt button
 - Updated file-ignore plugin configuration with complete structure including rules and history
 - Added changelog management instructions to CLAUDE.md
 - Removed [Unreleased] section from changelog format
-
-## [2025-06-29] - Documentation Updates
-
-### Added
-- CHANGELOG.md file following Keep a Changelog format
-- Project change tracking and versioning documentation
-
-## [2025-06-29] - Latest Changes
-
-### Added
-- Conventional commits guidelines to CLAUDE.md documentation
-- Cross-platform line ending configuration for consistent development
-- Site favicon from rlew.io
-- HTML page title suffixes for better SEO
-- Renovate bot configuration for automated dependency management
-- Enhanced Renovate configuration with project-specific settings
-
-### Changed
+- Moved architecture guidance from README to tips guide
+- Simplified README with correct repository links
+- Replaced prompt-content divs with horizontal rule detection
 - Updated build tools and dependencies via Renovate
 - Updated eleventy-notes dependencies
 - Updated @parcel/transformer-sass to match parcel version
 - Updated lucide dependency to ^0.525.0
+- Improved Jira ticket prompt with concrete examples and better formatting
 
 ### Fixed
 - Parcel version compatibility issues
 - Line ending consistency across platforms
-
-## [2025-06-29] - Site Architecture
-
-### Added
-- Eleventy-based AI prompts documentation site
-- Obsidian-style note-taking integration
-- Static site generation with wikilinks support
-- Task prompt template
-
-### Changed
-- Moved architecture guidance from README to tips guide
-- Simplified README with correct repository links
-- Replaced prompt-content divs with horizontal rule detection
+- Fixed prompt copy functionality to preserve markdown formatting instead of copying plain text
+- Updated copyPromptContent and fallbackCopyToClipboard methods to use markdown conversion
+- Filtered out copy-to-clipboard button elements and SVG icons from copied markdown content
+- Added whitespace normalization to prevent excessive newlines and formatting artifacts
 
 ### Removed
 - Server.log files (added to gitignore)
@@ -85,13 +65,6 @@ and this project adheres to [Conventional Commits](https://conventionalcommits.o
 
 ### Changed
 - Simplified TODO.md to focus on explicitly mentioned items
-
-## Project Versioning
-
-This project follows semantic versioning principles:
-- **MAJOR**: Incompatible API changes or significant architectural changes
-- **MINOR**: New features and functionality additions
-- **PATCH**: Bug fixes and small improvements
 
 ## Contributing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,66 @@ Before committing any changes to the repository, you MUST update the CHANGELOG.m
 ```
 
 **Important**: Always update the changelog BEFORE creating commits. Since commits to main are automatically published, each commit should have its changes documented with the current date.
+
+## Git Commit Guidelines
+
+This project follows [Conventional Commits](https://conventionalcommits.org/) specification. All commit messages MUST adhere to this format:
+
+### Commit Message Format
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Commit Types
+- **feat**: New feature or functionality
+- **fix**: Bug fix
+- **docs**: Documentation changes only
+- **style**: Code style changes (formatting, missing semicolons, etc.)
+- **refactor**: Code changes that neither fix bugs nor add features
+- **test**: Adding or updating tests
+- **chore**: Maintenance tasks, dependency updates, build changes
+- **perf**: Performance improvements
+- **ci**: CI/CD configuration changes
+
+### Examples
+
+#### Simple commit
+```
+fix: correct markdown formatting in prompt copy functionality
+```
+
+#### Commit with scope
+```
+feat(prompts): add new Jira ticket creation template
+```
+
+#### Multi-line commit with body
+```
+refactor: restructure prompt organization for better discoverability
+
+- Move all prompt templates to /prompts directory
+- Update navigation structure in app.mjs
+- Add categories for different prompt types
+```
+
+#### Breaking change
+```
+feat!: change prompt template format to use YAML frontmatter
+
+BREAKING CHANGE: All existing prompts must be updated to include
+YAML frontmatter with title and category fields.
+```
+
+### Guidelines
+1. Use present tense ("add feature" not "added feature")
+2. Use imperative mood ("fix bug" not "fixes bug")
+3. Don't capitalise the first letter of the description
+4. Don't end the description with a period
+5. Limit the first line to 72 characters
+6. Reference issues and PRs in the footer when applicable
+
+**Note**: The changelog should reflect these commit types in its categories (Added → feat, Fixed → fix, Changed → refactor/style, etc.)

--- a/prompts/create-jira-ticket.md
+++ b/prompts/create-jira-ticket.md
@@ -35,9 +35,9 @@ Description:
 
 ## Context (Background information, why this is needed, what's currently happening)
 
-## Acceptance criteria (Bullet points starting with * describing what needs to be done)
+## Acceptance criteria (Bullet points starting with - describing what needs to be done)
 
-## Other information (Optional - links, references, additional notes)    
+## Other information (Optional - bullet points starting with - for links, references, additional notes)
 ```
 
 Use professional, straightforward language focused on the technical issue. For bugs, explain what's wrong and what the correct behavior should be. For tasks, explain what needs to be created or changed.
@@ -46,10 +46,10 @@ Use professional, straightforward language focused on the technical issue. For b
 
 ### Example usage
 
-Create a Jira ticket for the [PROJECT_NAME] project with the following information:
+Create a Jira ticket for the CPORTAL project with the following information:
 
 **Problem/Issue**: 
-Our [FILENAME].md suggests single quotes for docstrings but PEP 257 and ruff require double quotes
+Our `style-guide.md` suggests single quotes for docstrings but PEP 257 and ruff require double quotes
 
 **Issue Type**: 
 Bug
@@ -58,5 +58,21 @@ Bug
 This conflicts with Python standards and our ruff formatter configuration
 
 **Expected Outcome**: 
-[FILENAME].md should recommend triple double quotes for docstrings to align with PEP 257
-"
+`style-guide.md` should recommend triple double quotes for docstrings to align with PEP 257
+
+Please format the ticket using this structure:
+
+Summary: Concise one-line description
+
+Description:
+```
+## Summary (Brief overview of the issue/task)
+
+## Context (Background information, why this is needed, what's currently happening)
+
+## Acceptance criteria (Bullet points starting with - describing what needs to be done)
+
+## Other information (Optional - bullet points starting with - for links, references, additional notes)
+```
+
+Use professional, straightforward language focused on the technical issue. For bugs, explain what's wrong and what the correct behavior should be. For tasks, explain what needs to be created or changed.


### PR DESCRIPTION
## Summary
• Fixed markdown formatting preservation when copying prompts to clipboard
• Updated copy functionality to maintain proper text structure and readability

## Test plan
- [ ] Test copying prompts with various markdown elements (headers, lists, code blocks)
- [ ] Verify clipboard content preserves original formatting
- [ ] Confirm functionality works across different browsers

🤖 Generated with [Claude Code](https://claude.ai/code)